### PR TITLE
Add support for addFiles config parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jest-runner-mocha maps some mocha CLI arguments to config options. For example `
 |ui|`"ui": "tdd"`
 |timeout|`"timeout": 10000`
 |compiler|`"compiler": "./path/to/babel-register"`
+|file|`"file": ["./path/to/include.js", "/supports/multiple/files.js"`]
 
 ### Coverage
 

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -56,6 +56,10 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
     coveragePathIgnorePatterns: config.coveragePathIgnorePatterns,
   });
 
+  if (mochaOptions.file) {
+    mochaOptions.file.forEach(file => mocha.addFile(file));
+  }
+
   mocha.addFile(testPath);
 
   const onEnd = () => {

--- a/src/utils/getMochaOptions.js
+++ b/src/utils/getMochaOptions.js
@@ -10,6 +10,17 @@ const normalize = (jestConfig, { cliOptions: rawCliOptions = {} }) => {
     cliOptions.compiler = path.resolve(jestConfig.rootDir, cliOptions.compiler);
   }
 
+  if (cliOptions.file) {
+    const file = [].concat(cliOptions.file);
+    cliOptions.file = file.map(f => {
+      if (path.isAbsolute(f)) {
+        return f;
+      }
+
+      return path.resolve(jestConfig.rootDir, f);
+    });
+  }
+
   return { cliOptions };
 };
 


### PR DESCRIPTION
Hello!

First of all, thank you for this project! It's truly saving me from laborious long test runs when using mocha directly.

For the tests that I run I have the need to run additional files before each test file to set up some additional Mocha hooks.

i.e. in one file I have a 

```javascript
before(function() {
  // Do stuff before any of my tests run.
});
```

I was able to add this functionality through this change.

Sorry about not creating an issue first. I've been hacking on this all this day to get this working with our test suite and this is part 1 of 2 of changes that I'd love to upstream.