### PR TITLE
Handle when an error occurs in a beforeEach block of a mocha test.

### DIFF
--- a/integrationTests/__fixtures__/errorInBeforeEach/__mocha__/__tests__/file.test.js
+++ b/integrationTests/__fixtures__/errorInBeforeEach/__mocha__/__tests__/file.test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-unreachable */
+const assert = require('assert');
+
+describe('My tests', () => {
+  it('This test passes', () => {
+    assert.equal(1, 1);
+  });
+
+  describe('Nested describe', () => {
+    beforeEach(() => {
+      throw new Error('Error in nested beforeEach');
+    });
+
+    it('This nested test passes', () => {
+      assert.equal(1, 1);
+    });
+  });
+});

--- a/integrationTests/__fixtures__/errorInBeforeEach/jest.config.js
+++ b/integrationTests/__fixtures__/errorInBeforeEach/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  runner: '../../../',
+};

--- a/integrationTests/__snapshots__/errorInBeforeEach.test.js.snap
+++ b/integrationTests/__snapshots__/errorInBeforeEach.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Works when it has an error inside of beforeEach 1`] = `
+"FAIL integrationTests/__fixtures__/errorInBeforeEach/__mocha__/__tests__/file.test.js
+    My tests Nested describe \\"before each\\" hook for \\"This nested test passes\\"
+Error: Error in nested beforeEach
+      at mocked-stack-trace
+  ✓ This test passes
+  ✕ \\"before each\\" hook for \\"This nested test passes\\"
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 passed, 2 total
+Snapshots:   0 total
+Time:
+Ran all test suites.
+
+"
+`;

--- a/integrationTests/errorInBeforeEach.test.js
+++ b/integrationTests/errorInBeforeEach.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('Works when it has an error inside of beforeEach', () => {
+  return expect(runJest('errorInBeforeEach')).resolves.toMatchSnapshot();
+});

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -16,7 +16,10 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
 
       runner.on('test end', test => tests.push(test));
       runner.on('pass', test => passes.push(test));
-      runner.on('fail', test => failures.push(test));
+      runner.on('fail', (test, err) => {
+        test.err = err;
+        failures.push(test);
+      });
       runner.on('pending', test => pending.push(test));
       runner.on('end', () => {
         try {

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -9,21 +9,18 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
   class Reporter extends Mocha.reporters.Base {
     constructor(runner) {
       super(runner);
-      const tests = new Set();
-      const pending = new Set();
-      const failures = new Set();
-      const passes = new Set();
+      const tests = [];
+      const pending = [];
+      const failures = [];
+      const passes = [];
 
-      runner.on('test end', test => tests.add(test));
-      runner.on('pass', test => passes.add(test));
+      runner.on('test end', test => tests.push(test));
+      runner.on('pass', test => passes.push(test));
       runner.on('fail', (test, err) => {
         test.err = err;
-        failures.add(test);
-
-        // Ensure we include failing tests in our final set of tests.
-        tests.add(test);
+        failures.push(test);
       });
-      runner.on('pending', test => pending.add(test));
+      runner.on('pending', test => pending.push(test));
       runner.on('end', () => {
         try {
           workerCallback(

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -9,18 +9,21 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
   class Reporter extends Mocha.reporters.Base {
     constructor(runner) {
       super(runner);
-      const tests = [];
-      const pending = [];
-      const failures = [];
-      const passes = [];
+      const tests = new Set();
+      const pending = new Set();
+      const failures = new Set();
+      const passes = new Set();
 
-      runner.on('test end', test => tests.push(test));
-      runner.on('pass', test => passes.push(test));
+      runner.on('test end', test => tests.add(test));
+      runner.on('pass', test => passes.add(test));
       runner.on('fail', (test, err) => {
         test.err = err;
-        failures.push(test);
+        failures.add(test);
+
+        // Ensure we include failing tests in our final set of tests.
+        tests.add(test);
       });
-      runner.on('pending', test => pending.push(test));
+      runner.on('pending', test => pending.add(test));
       runner.on('end', () => {
         try {
           workerCallback(

--- a/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
@@ -41,7 +41,8 @@ Error stack
     Object {
       "ancestorTitles": Array [],
       "duration": 0.004,
-      "failureMessages": "
+      "failureMessages": Array [
+        "
     This test failed
 
       [31mThe error message[0m
@@ -53,6 +54,7 @@ Error stack
 Error stack
 
 ",
+      ],
       "fullName": "This test failed",
       "numPassingAsserts": 1,
       "status": "failed",
@@ -90,7 +92,7 @@ Object {
     Object {
       "ancestorTitles": Array [],
       "duration": 0.001,
-      "failureMessages": null,
+      "failureMessages": Array [],
       "fullName": "This test passes[1]",
       "numPassingAsserts": 0,
       "status": "passed",
@@ -130,7 +132,7 @@ Object {
     Object {
       "ancestorTitles": Array [],
       "duration": 0.001,
-      "failureMessages": null,
+      "failureMessages": Array [],
       "fullName": "This test passes[1]",
       "numPassingAsserts": 0,
       "status": "passed",
@@ -181,7 +183,7 @@ Error stack
     Object {
       "ancestorTitles": Array [],
       "duration": 0.001,
-      "failureMessages": null,
+      "failureMessages": Array [],
       "fullName": "This test passes[1]",
       "numPassingAsserts": 0,
       "status": "passed",
@@ -190,7 +192,7 @@ Error stack
     Object {
       "ancestorTitles": Array [],
       "duration": 0.004,
-      "failureMessages": null,
+      "failureMessages": Array [],
       "fullName": "This test also passes[2]",
       "numPassingAsserts": 0,
       "status": "passed",
@@ -199,7 +201,8 @@ Error stack
     Object {
       "ancestorTitles": Array [],
       "duration": 0.004,
-      "failureMessages": "
+      "failureMessages": Array [
+        "
     This test failed
 
       [31mThe error message[0m
@@ -211,6 +214,7 @@ Error stack
 Error stack
 
 ",
+      ],
       "fullName": "This test failed",
       "numPassingAsserts": 1,
       "status": "failed",

--- a/src/utils/__tests__/toTestResult.test.js
+++ b/src/utils/__tests__/toTestResult.test.js
@@ -41,6 +41,7 @@ it('turns a passing mocha tests to Jest test result', () => {
         failures: 0,
       },
       tests: [passingTest],
+      failures: [],
     }),
   ).toMatchSnapshot();
 });
@@ -58,6 +59,7 @@ it('turns a passing mocha tests to Jest test result with coverage', () => {
         failures: 0,
       },
       tests: [passingTest],
+      failures: [],
     }),
   ).toMatchSnapshot();
 });
@@ -74,6 +76,7 @@ it('turns a failing mocha tests to Jest test result', () => {
         failures: 1,
       },
       tests: [failingTest],
+      failures: [],
     }),
   ).toMatchSnapshot();
 });
@@ -90,6 +93,7 @@ it('turns a whole mocha tests suite to Jest test result', () => {
         failures: 0,
       },
       tests: [passingTest, passingTest2, failingTest],
+      failures: [],
     }),
   ).toMatchSnapshot();
 });

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -19,7 +19,7 @@ const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
   // Merge failed tests that don't exist in the tests array so that we report
   // all tests even if an error occurs in a beforeEach block.
   failures.forEach(test => {
-    if (!tests.includes(test)) {
+    if (!tests.some(t => t === test)) {
       tests.push(test);
     }
   });

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -13,12 +13,21 @@ const getFailureMessages = tests => {
   return failureMessages.length ? failureMessages : null;
 };
 
-const toTestResult = ({ stats, tests: testsSet, jestTestPath, coverage }) => {
-  const tests = Array.from(testsSet);
+const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
+  const effectiveTests = tests;
+
+  // Merge failed tests that don't exist in the tests array so that we report
+  // all tests even if an error occurs in a beforeEach block.
+  failures.forEach(test => {
+    if (!tests.some(t => t === test)) {
+      tests.push(test);
+    }
+  });
+
   return {
     coverage,
     console: null,
-    failureMessage: getFailureMessages(tests),
+    failureMessage: getFailureMessages(effectiveTests),
     numFailingTests: stats.failures,
     numPassingTests: stats.passes,
     numPendingTests: stats.pending,
@@ -38,7 +47,7 @@ const toTestResult = ({ stats, tests: testsSet, jestTestPath, coverage }) => {
     sourceMaps: {},
     testExecError: null,
     testFilePath: jestTestPath,
-    testResults: tests.map(test => {
+    testResults: effectiveTests.map(test => {
       return {
         ancestorTitles: [],
         duration: test.duration / 1000,

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -13,11 +13,21 @@ const getFailureMessages = tests => {
   return failureMessages.length ? failureMessages : null;
 };
 
-const toTestResult = ({ stats, tests, jestTestPath, coverage }) => {
+const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
+  const effectiveTests = tests;
+
+  // Merge failed tests that don't exist in the tests array so that we report
+  // all tests even if an error occurs in a beforeEach block.
+  failures.forEach(test => {
+    if (!tests.includes(test)) {
+      tests.push(test);
+    }
+  });
+
   return {
     coverage,
     console: null,
-    failureMessage: getFailureMessages(tests),
+    failureMessage: getFailureMessages(effectiveTests),
     numFailingTests: stats.failures,
     numPassingTests: stats.passes,
     numPendingTests: stats.pending,
@@ -37,7 +47,7 @@ const toTestResult = ({ stats, tests, jestTestPath, coverage }) => {
     sourceMaps: {},
     testExecError: null,
     testFilePath: jestTestPath,
-    testResults: tests.map(test => {
+    testResults: effectiveTests.map(test => {
       return {
         ancestorTitles: [],
         duration: test.duration / 1000,

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -13,21 +13,12 @@ const getFailureMessages = tests => {
   return failureMessages.length ? failureMessages : null;
 };
 
-const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
-  const effectiveTests = tests;
-
-  // Merge failed tests that don't exist in the tests array so that we report
-  // all tests even if an error occurs in a beforeEach block.
-  failures.forEach(test => {
-    if (!tests.some(t => t === test)) {
-      tests.push(test);
-    }
-  });
-
+const toTestResult = ({ stats, tests: testsSet, jestTestPath, coverage }) => {
+  const tests = Array.from(testsSet);
   return {
     coverage,
     console: null,
-    failureMessage: getFailureMessages(effectiveTests),
+    failureMessage: getFailureMessages(tests),
     numFailingTests: stats.failures,
     numPassingTests: stats.passes,
     numPendingTests: stats.pending,
@@ -47,7 +38,7 @@ const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
     sourceMaps: {},
     testExecError: null,
     testFilePath: jestTestPath,
-    testResults: effectiveTests.map(test => {
+    testResults: tests.map(test => {
       return {
         ancestorTitles: [],
         duration: test.duration / 1000,

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -48,10 +48,11 @@ const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
     testExecError: null,
     testFilePath: jestTestPath,
     testResults: effectiveTests.map(test => {
+      const failureMessage = toMochaError(test);
       return {
         ancestorTitles: [],
         duration: test.duration / 1000,
-        failureMessages: toMochaError(test),
+        failureMessages: failureMessage ? [failureMessage] : [],
         fullName: test.fullTitle(),
         numPassingAsserts: hasError(test) ? 1 : 0,
         status: hasError(test) ? 'failed' : 'passed',


### PR DESCRIPTION
Hello, it's me again! Apologies for the PR's without issues!

This adds support to surface when an error occurs in a beforeEach block, before any individual tests run.

Without this change this is what is shown:

![image](https://user-images.githubusercontent.com/322576/34232836-38a967aa-e5b0-11e7-8f86-4ea81ba2e2f6.png)

With this change we show:

![image](https://user-images.githubusercontent.com/322576/34232842-4990dc88-e5b0-11e7-8e08-604772117d83.png)
