### PR TITLE
Add ancestors to handle describe block nesting

### DIFF
--- a/integrationTests/__snapshots__/errorInBeforeEach.test.js.snap
+++ b/integrationTests/__snapshots__/errorInBeforeEach.test.js.snap
@@ -5,8 +5,11 @@ exports[`Works when it has an error inside of beforeEach 1`] = `
     My tests Nested describe \\"before each\\" hook for \\"This nested test passes\\"
 Error: Error in nested beforeEach
       at mocked-stack-trace
-  ✓ This test passes
-  ✕ \\"before each\\" hook for \\"This nested test passes\\"
+  My tests
+    ✓ This test passes
+  Nested describe
+    My tests
+      ✕ \\"before each\\" hook for \\"This nested test passes\\"
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 passed, 2 total
 Snapshots:   0 total

--- a/integrationTests/__snapshots__/errorOutsideTest.test.js.snap
+++ b/integrationTests/__snapshots__/errorOutsideTest.test.js.snap
@@ -5,7 +5,8 @@ exports[`Works when it has an error outside the tests 1`] = `
     My tests This test thows an error
 Error: Some error message
       at mocked-stack-trace
-  ✕ This test thows an error
+  My tests
+    ✕ This test thows an error
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total

--- a/integrationTests/__snapshots__/failing.test.js.snap
+++ b/integrationTests/__snapshots__/failing.test.js.snap
@@ -8,7 +8,8 @@ exports[`Works when it has failing tests 1`] = `
       [31m-1[0m
       [32m+2[0m
       at mocked-stack-trace
-  ✕ This test fails
+  My tests
+    ✕ This test fails
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total

--- a/integrationTests/__snapshots__/passing.test.js.snap
+++ b/integrationTests/__snapshots__/passing.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`Works when it has only passing tests 1`] = `
 "PASS integrationTests/__fixtures__/passing/__mocha__/__tests__/file.test.js
-  ✓ This test passes
+  My tests
+    ✓ This test passes
 Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total
@@ -13,7 +14,8 @@ Ran all test suites.
 
 exports[`Works when it has only passing tests and --coverage 1`] = `
 "PASS integrationTests/__fixtures__/passing/__mocha__/__tests__/file.test.js
-  ✓ This test passes
+  My tests
+    ✓ This test passes
 Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total

--- a/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
@@ -190,7 +190,9 @@ Error stack
       "title": "This test passes[1]",
     },
     Object {
-      "ancestorTitles": Array [],
+      "ancestorTitles": Array [
+        "Some describe block",
+      ],
       "duration": 0.004,
       "failureMessages": Array [],
       "fullName": "This test also passes[2]",

--- a/src/utils/__tests__/toTestResult.test.js
+++ b/src/utils/__tests__/toTestResult.test.js
@@ -4,6 +4,11 @@ const jestTestPath = 'path/to/file';
 const start = Date.UTC(2000, 0, 1, 0, 0, 0, 0);
 const end = start + 1000;
 
+const withDescribe = (title, test) =>
+  Object.assign({}, test, {
+    parent: { title },
+  });
+
 const passingTest = {
   duration: 1,
   title: 'This test passes[1]',
@@ -92,7 +97,11 @@ it('turns a whole mocha tests suite to Jest test result', () => {
         pending: 0,
         failures: 0,
       },
-      tests: [passingTest, passingTest2, failingTest],
+      tests: [
+        passingTest,
+        withDescribe('Some describe block', passingTest2),
+        failingTest,
+      ],
       failures: [],
     }),
   ).toMatchSnapshot();

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -13,6 +13,14 @@ const getFailureMessages = tests => {
   return failureMessages.length ? failureMessages : null;
 };
 
+const getAncestorTitle = test => {
+  if (test.parent && test.parent.title) {
+    return [test.parent.title].concat(getAncestorTitle(test.parent));
+  }
+
+  return [];
+};
+
 const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
   const effectiveTests = tests;
 
@@ -50,7 +58,7 @@ const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
     testResults: effectiveTests.map(test => {
       const failureMessage = toMochaError(test);
       return {
-        ancestorTitles: [],
+        ancestorTitles: getAncestorTitle(test),
         duration: test.duration / 1000,
         failureMessages: failureMessage ? [failureMessage] : [],
         fullName: test.fullTitle(),


### PR DESCRIPTION
This PR populates the ancestors field. This means that describe blocks will now be properly nested in the test results

 
![screen shot 2018-02-26 at 10 00 07 am](https://user-images.githubusercontent.com/574806/36686625-da75548a-1adb-11e8-9b25-1a6fb65e7783.png)
