### PR TITLE
allow configuration of coverage babelrc usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ In `package.json`
   "jest-runner-mocha": {
     "cliOptions": {
       // Options here
+    },
+    "coverageOptions": {
+      // Options here
     }
   }
 }
@@ -70,6 +73,9 @@ or in `jest-runner-mocha.config.js`
 ```js
 module.exports = {
   cliOptions: {
+    // Options here
+  },
+  "coverageOptions": {
     // Options here
   }
 }
@@ -86,6 +92,14 @@ jest-runner-mocha maps some mocha CLI arguments to config options. For example `
 |timeout|`"timeout": 10000`
 |compiler|`"compiler": "./path/to/babel-register"`
 |file|`"file": ["./path/to/include.js", "/supports/multiple/files.js"`]
+
+### coverageOptions
+
+jest-runner-mocha has some optional configuration for code coverage
+
+|option|example|description|
+|-----|-----|-----|
+|useBabelRc|`"useBabelRc": true`|read .babelrc when instrumenting for code coverage (required if you transpile your code with babel).|
 
 ### Coverage
 

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -4,7 +4,7 @@ const setupCollectCoverage = require('./utils/setupCollectCoverage');
 const getMochaOptions = require('./utils/getMochaOptions');
 
 const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
-  const { cliOptions: mochaOptions } = getMochaOptions(config);
+  const { cliOptions: mochaOptions, coverageOptions } = getMochaOptions(config);
 
   class Reporter extends Mocha.reporters.Base {
     constructor(runner) {
@@ -57,6 +57,7 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
     rootDir: config.rootDir,
     collectCoverage: globalConfig.collectCoverage,
     coveragePathIgnorePatterns: config.coveragePathIgnorePatterns,
+    allowBabelRc: coverageOptions.useBabelRc
   });
 
   if (mochaOptions.file) {

--- a/src/utils/getMochaOptions.js
+++ b/src/utils/getMochaOptions.js
@@ -3,7 +3,7 @@ const cosmiconfig = require('cosmiconfig');
 
 const explorer = cosmiconfig('jest-runner-mocha', { sync: true });
 
-const normalize = (jestConfig, { cliOptions: rawCliOptions = {} }) => {
+  const normalize = (jestConfig, { cliOptions: rawCliOptions = {}, coverageOptions = { allowBabelRc: false }}) => {
   const cliOptions = Object.assign({}, rawCliOptions);
 
   if (cliOptions.compiler && !path.isAbsolute(cliOptions.compiler)) {
@@ -21,7 +21,7 @@ const normalize = (jestConfig, { cliOptions: rawCliOptions = {} }) => {
     });
   }
 
-  return { cliOptions };
+  return { cliOptions, coverageOptions };
 };
 
 const getMochaOptions = jestConfig => {

--- a/src/utils/setupCollectCoverage.js
+++ b/src/utils/setupCollectCoverage.js
@@ -4,6 +4,7 @@ const setupCollectCoverage = ({
   rootDir,
   collectCoverage,
   coveragePathIgnorePatterns,
+  allowBabelRc
 }) => {
   if (!collectCoverage) {
     return;
@@ -29,7 +30,7 @@ const setupCollectCoverage = ({
         coveragePathIgnorePatterns.some(pattern => minimatch(filename, pattern))
       );
     },
-    babelrc: false,
+    babelrc: allowBabelRc,
     // compact: true,
     retainLines: true,
     sourceMaps: 'inline',


### PR DESCRIPTION
I think ideally the runner wouldn't depend on babel to instrument for code coverage. I'm not sure what the correct answer is but this could unblock some of us with the option to use the babelrc if specified.

Addresses #13 