### PR TITLE
use mocha as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "cosmiconfig": "^3.1.0",
     "lodash": "4.17.4",
     "minimatch": "3.0.4",
-    "mocha": "3.5.0",
     "pify": "3.0.0",
     "throat": "4.1.0",
     "worker-farm": "1.5.0"
@@ -44,6 +43,10 @@
     "eslint-plugin-prettier": "2.2.0",
     "execa": "0.8.0",
     "jest": "21.0.1",
+    "mocha": "3.5.0",
     "prettier": "1.7.4"
+  },
+  "peerDependencies": {
+    "mocha": "*"
   }
 }


### PR DESCRIPTION
Using mocha as a peer dependency does not break old node (developer will only need to specify mocha version they need in package.json) but allows to use latest version of mocha as requested here https://github.com/rogeliog/jest-runner-mocha/issues/6