### PR TITLE
setupFilesAfterEnv and clearMocks support

### DIFF
--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -66,8 +66,8 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
     allowBabelRc: coverageOptions.useBabelRc,
   });
 
-  if (config.setupFiles) {
-    config.setupFiles.forEach(path => {
+  if (config.setupFilesAfterEnv) {
+    config.setupFilesAfterEnv.forEach(path => {
       // eslint-disable-next-line global-require,import/no-dynamic-require
       const module = require(path);
       if (config.clearMocks && module.clearMocks) {

--- a/src/runMocha.js
+++ b/src/runMocha.js
@@ -70,7 +70,7 @@ const runMocha = ({ config, testPath, globalConfig }, workerCallback) => {
     config.setupFiles.forEach(path => {
       // eslint-disable-next-line global-require,import/no-dynamic-require
       const module = require(path);
-      if (module.clearMocks) {
+      if (config.clearMocks && module.clearMocks) {
         clearMocks = module.clearMocks;
       }
     });


### PR DESCRIPTION
This is a quick and a bit dirty solution for https://github.com/rogeliog/jest-runner-mocha/issues/24

It does not break anything but lets you use `setupFilesAfterEnv` and use `clearMocks` if it is enabled and exported from one of the setup files.

For example, we use sinon but we can enjoy independent mocks with a simple clearMocks implementation:

```
const sinon = require('sinon');
module.exports = {
	clearMocks: () => {
		sinon.sandbox.restore();
	}
};
```

I'm not sure if it will play as well with clearing jests's native mocks - but right now clearing native mocks does't work anyway.