### PR TITLE
fix failureMessage display

### DIFF
--- a/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/toTestResult.test.js.snap
@@ -4,8 +4,7 @@ exports[`turns a failing mocha tests to Jest test result 1`] = `
 Object {
   "console": null,
   "coverage": undefined,
-  "failureMessage": Array [
-    "
+  "failureMessage": "
     This test failed
 
       [31mThe error message[0m
@@ -17,7 +16,6 @@ Object {
 Error stack
 
 ",
-  ],
   "numFailingTests": 1,
   "numPassingTests": 0,
   "numPendingTests": 0,
@@ -146,8 +144,7 @@ exports[`turns a whole mocha tests suite to Jest test result 1`] = `
 Object {
   "console": null,
   "coverage": undefined,
-  "failureMessage": Array [
-    "
+  "failureMessage": "
     This test failed
 
       [31mThe error message[0m
@@ -159,7 +156,6 @@ Object {
 Error stack
 
 ",
-  ],
   "numFailingTests": 0,
   "numPassingTests": 1,
   "numPendingTests": 0,

--- a/src/utils/toTestResult.js
+++ b/src/utils/toTestResult.js
@@ -8,9 +8,9 @@ const hasError = (test = {}) => {
 const toMochaError = test =>
   hasError(test) ? `\n${formatMochaError(test)}\n\n` : null;
 
-const getFailureMessages = tests => {
+const getFailureMessage = tests => {
   const failureMessages = tests.filter(hasError).map(toMochaError);
-  return failureMessages.length ? failureMessages : null;
+  return failureMessages.length ? failureMessages.join('') : null;
 };
 
 const getAncestorTitle = test => {
@@ -35,7 +35,7 @@ const toTestResult = ({ stats, tests, failures, jestTestPath, coverage }) => {
   return {
     coverage,
     console: null,
-    failureMessage: getFailureMessages(effectiveTests),
+    failureMessage: getFailureMessage(effectiveTests),
     numFailingTests: stats.failures,
     numPassingTests: stats.passes,
     numPendingTests: stats.pending,


### PR DESCRIPTION
On my project I had a trouble with displaying test errors - instead of error text, some kind of array was logged:

![image](https://user-images.githubusercontent.com/2296742/73477901-2275d080-43a6-11ea-8180-eafba255b81d.png)

I looked through the code and saw that failureMessage seems to be supposed a string, not an array. So I simply put a `join('')` there - and now everything seems to work fine.

![image](https://user-images.githubusercontent.com/2296742/73477951-3a4d5480-43a6-11ea-9330-6a8638e0ce44.png)

I checked this on several differents reporters and results were same.
May be jest accepted failureMessage as an array before, bit now it expects string.
I suppose that this should be checked on other project setups as well.